### PR TITLE
Method signature of AuditEntry::getErrors should be same as yii\base\Model::getErrors

### DIFF
--- a/models/AuditEntry.php
+++ b/models/AuditEntry.php
@@ -61,7 +61,7 @@ class AuditEntry extends AuditModel
      * Returns all linked AuditError instances
      * @return AuditError[]
      */
-    public function getErrors()
+    public function getErrors($attribute = NULL)
     {
         return static::hasMany(AuditError::className(), ['audit_id' => 'id']);
     }


### PR DESCRIPTION
Method signature of AuditEntry::getErrors should be same as Yii2 yii\base\Model::getErrors