### PR TITLE
use id instead of SerialColumn

### DIFF
--- a/views/default/index.php
+++ b/views/default/index.php
@@ -20,7 +20,8 @@
         'dataProvider' => $dataProvider,
         'filterModel' => $searchModel,
         'columns' => [
-            ['class' => 'yii\grid\SerialColumn'],
+            //['class' => 'yii\grid\SerialColumn'],
+            'id',
             [
                 'attribute' => 'user_id',
                 'label' => Yii::t('audit', 'User ID'),


### PR DESCRIPTION
it seems to me that ID is a lot more important than a serial ID.

1) the serial ID changes every time i reload or goto another page.
2) the ID is given to me by the error emailer, so i need to jump to the view page of the ID