### PR TITLE
Bootstrap Array to String conversion fix #145

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -28,7 +28,7 @@ class Bootstrap implements BootstrapInterface
         if ($moduleName) {
             // The module was added in the configuration, make sure to add it to the application bootstrap so it gets loaded
             $app->bootstrap[] = $moduleName;
-            $app->bootstrap = array_unique($app->bootstrap);
+            $app->bootstrap = array_unique($app->bootstrap, SORT_REGULAR);
         }
 
         if ($app->has('i18n')) {


### PR DESCRIPTION
Hey There,

as reviewing your extension I came across some bugs. One of them being the bootstrap bug.
Yii2 allows multidimensional arrays to be put into the application's bootstrap (see http://www.yiiframework.com/doc-2.0/yii-filters-contentnegotiator.html)

When this type of bootstrap is used the application will spit out 'Array to String conversion' errors.
In order to fix this you can change a single line of code found in Bootstrap.php lines 28 to 32.

```php
if ($moduleName) {
    // The module was added in the configuration, make sure to add it to the application bootstrap so it gets loaded
    $app->bootstrap[] = $moduleName;
    $app->bootstrap = array_unique($app->bootstrap, SORT_REGULAR);
}
```

(original: https://github.com/bedezign/yii2-audit/blob/a845ba3f69cf9a24f1efaecce0cf6b05bb4c249b/src/Bootstrap.php#L31)

Hope this helps anyone :+1: 