### PR TITLE
save user_id on finalize function

### DIFF
--- a/src/models/AuditEntry.php
+++ b/src/models/AuditEntry.php
@@ -171,9 +171,17 @@ class AuditEntry extends ActiveRecord
      */
     public function finalize()
     {
+        $app = Yii::$app;
+        $request = $app->request;
+        $user = $app->user;
+
+        if ($request instanceof \yii\web\Request) {
+            $this->user_id = $user->isGuest ? 0 : $user->id;
+        }
+	
         $this->duration = microtime(true) - YII_BEGIN_TIME;
         $this->memory_max = memory_get_peak_usage();
-        return $this->save(false, ['duration', 'memory_max']);
+        return $this->save(false, ['duration', 'memory_max', 'user_id']);
     }
 
     /**

--- a/src/models/AuditEntry.php
+++ b/src/models/AuditEntry.php
@@ -175,7 +175,7 @@ class AuditEntry extends ActiveRecord
         $request = $app->request;
         $user = $app->user;
 
-        if ($request instanceof \yii\web\Request) {
+        if (!$this->user_id && $request instanceof \yii\web\Request) {
             $this->user_id = $user->isGuest ? 0 : $user->id;
         }
 	


### PR DESCRIPTION
fixes #152
Yii::$app->user->id is set after beforeAction when using `HttpBearerAuth`, `QueryParamAuth`, `HttpBasicAuth`