### PR TITLE
Fix audit entry always showing user as guest

### DIFF
--- a/src/models/AuditEntry.php
+++ b/src/models/AuditEntry.php
@@ -171,11 +171,16 @@ class AuditEntry extends ActiveRecord
      */
     public function finalize()
     {
-        $user = Yii::$app->user;
         $this->duration = microtime(true) - YII_BEGIN_TIME;
-        $this->user_id  = $user->isGuest ? 0 : $user->id;
         $this->memory_max = memory_get_peak_usage();
-        return $this->save(false, ['duration', 'memory_max', 'user_id']);
+
+        if (Yii::$app->request instanceof \yii\web\Request) {
+            $user = Yii::$app->user;
+            $this->user_id  = $user->isGuest ? 0 : $user->id;
+            return $this->save(false, ['duration', 'memory_max', 'user_id']);
+        } else {
+            return $this->save(false, ['duration', 'memory_max']);
+        }
     }
 
     /**

--- a/src/models/AuditEntry.php
+++ b/src/models/AuditEntry.php
@@ -171,9 +171,11 @@ class AuditEntry extends ActiveRecord
      */
     public function finalize()
     {
+        $user = Yii::$app->user;
         $this->duration = microtime(true) - YII_BEGIN_TIME;
+        $this->user_id  = $user->isGuest ? 0 : $user->id;
         $this->memory_max = memory_get_peak_usage();
-        return $this->save(false, ['duration', 'memory_max']);
+        return $this->save(false, ['duration', 'memory_max', 'user_id']);
     }
 
     /**


### PR DESCRIPTION
In cases where sessions is not used (eg: token based authentication)  `$user->isGuest` in the `record` function of the AuditEntry Model returns false because the required token-authentication function has not been run. 

Checking for a valid user in the `finalize` function ensures that if a user has been successfully authenticated,  he/she is associated with the audit entry.