### PR TITLE
fix $app->user failing for CLI requests

### DIFF
--- a/src/models/AuditEntry.php
+++ b/src/models/AuditEntry.php
@@ -173,9 +173,9 @@ class AuditEntry extends ActiveRecord
     {
         $app = Yii::$app;
         $request = $app->request;
-        $user = $app->user;
 
         if (!$this->user_id && $request instanceof \yii\web\Request) {
+            $user = $app->user;
             $this->user_id = $user->isGuest ? 0 : $user->id;
         }
 	


### PR DESCRIPTION
the `finalize()` function of AuditEntry Model fails on CLI requests due to `$user = $app->user;`