### PR TITLE
Feature/fix charts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-bcmath": "*",
         "yiisoft/yii2": "2.*",
         "yiisoft/yii2-debug": "2.*",
-        "2amigos/yii2-chartjs-widget": "2.*",
+        "2amigos/yii2-chartjs-widget": "2.0.1 || 3.*",
         "phpspec/php-diff": "1.*"
     },
     "autoload": {

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -32,7 +32,7 @@ $this->registerCss('canvas {width: 100% !important;height: 400px;}');
                     $count[] = AuditEntry::find()->where(['between', 'created', date('Y-m-d 00:00:00', $date), date('Y-m-d 23:59:59', $date)])->count();
                 }
                 echo ChartJs::widget([
-                    'type' => 'Bar',
+                    'type' => 'bar',
                     'data' => [
                         'labels' => $days,
                         'datasets' => [

--- a/src/views/default/panels/error/chart.php
+++ b/src/views/default/panels/error/chart.php
@@ -14,7 +14,7 @@ foreach (range(-6, 0) as $day) {
 }
 
 echo ChartJs::widget([
-    'type' => 'Bar',
+    'type' => 'bar',
     'data' => [
         'labels' => $days,
         'datasets' => [

--- a/src/views/default/panels/javascript/chart.php
+++ b/src/views/default/panels/javascript/chart.php
@@ -14,7 +14,7 @@ foreach (range(-6, 0) as $day) {
 }
 
 echo ChartJs::widget([
-    'type' => 'Bar',
+    'type' => 'bar',
     'data' => [
         'labels' => $days,
         'datasets' => [

--- a/src/views/default/panels/mail/chart.php
+++ b/src/views/default/panels/mail/chart.php
@@ -14,7 +14,7 @@ foreach (range(-6, 0) as $day) {
 }
 
 echo ChartJs::widget([
-    'type' => 'Bar',
+    'type' => 'bar',
     'data' => [
         'labels' => $days,
         'datasets' => [

--- a/src/views/default/panels/trail/chart.php
+++ b/src/views/default/panels/trail/chart.php
@@ -14,7 +14,7 @@ foreach (range(-6, 0) as $day) {
 }
 
 echo ChartJs::widget([
-    'type' => 'Bar',
+    'type' => 'bar',
     'data' => [
         'labels' => $days,
         'datasets' => [


### PR DESCRIPTION
I can't get 1.x to work anymore, maybe because of a browser/canvas/whatever?! issue.

These changes fix the audit module for chartjs 2.1.x (npm) and 2amigos/yii2-chartjs (2.0.1).

### About the composer.json changes

Depending on the version tagging policy of 2amigos, this might be changed to ^2.0.1 (chartJs 1.x) or ^3.0.0 (chartJs 2.x)
see also 2amigos/yii2-chartjs-widget@9e9c552#commitcomment-18391242

---

Also the look is a bit different and could be improved... but better than empty charts :)

![bildschirmfoto 2016-07-28 um 08 55 54](https://cloud.githubusercontent.com/assets/649031/17203875/4b1a7852-54a2-11e6-81b9-81ae481b5243.png)

@tonydspaniard @cornernote 