### PR TITLE
fixed yii2-debug constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=5.4.0",
         "ext-bcmath": "*",
         "yiisoft/yii2": "2.*",
-        "yiisoft/yii2-debug": "2.*",
+        "yiisoft/yii2-debug": "^2.0.7",
         "2amigos/yii2-chartjs-widget": "2.0.1 || 3.*",
         "phpspec/php-diff": "1.*"
     },


### PR DESCRIPTION
for details see https://github.com/yiisoft/yii2-debug/issues/169

I think with the current version you can not go lower than 2.0.7, since the method signature won't match there.

*untested*