### PR TITLE
#174 Ability to use custom user id instead Yii::$app->user->id

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -12,7 +12,6 @@ namespace bedezign\yii2\audit;
 
 use bedezign\yii2\audit\components\panels\Panel;
 use bedezign\yii2\audit\models\AuditEntry;
-use bedezign\yii2\audit\models\AuditError;
 use Yii;
 use yii\base\ActionEvent;
 use yii\base\Application;
@@ -101,6 +100,11 @@ class Audit extends Module
      * @var string The callback to use to convert a user id into an identifier (username, email, ...). Can also be html.
      */
     public $userIdentifierCallback = false;
+
+    /**
+     * @var string The callback to get a user id.
+     */
+    public $userIdCallback = false;
 
     /**
      * @var string Will be called to translate text in the user filter into a (or more) user id's
@@ -304,6 +308,17 @@ class Audit extends Module
             return call_user_func($this->userIdentifierCallback, $user_id);
         }
         return $user_id;
+    }
+
+    /**
+     * @return int|mixed|null|string
+     */
+    public function getUserId()
+    {
+        if ($this->userIdCallback && is_callable($this->userIdCallback)) {
+            return call_user_func($this->userIdCallback);
+        }
+        return (Yii::$app instanceof Application && Yii::$app->user) ? Yii::$app->user->id : null;
     }
 
     /**

--- a/src/AuditTrailBehavior.php
+++ b/src/AuditTrailBehavior.php
@@ -328,7 +328,7 @@ class AuditTrailBehavior extends \yii\base\Behavior
      */
     protected function getUserId()
     {
-        return (Yii::$app instanceof Application && Yii::$app->user) ? Yii::$app->user->id : null;
+        return Audit::getInstance()->getUserId();
     }
 
     /**

--- a/src/models/AuditEntry.php
+++ b/src/models/AuditEntry.php
@@ -2,6 +2,7 @@
 
 namespace bedezign\yii2\audit\models;
 
+use bedezign\yii2\audit\Audit;
 use bedezign\yii2\audit\components\db\ActiveRecord;
 use bedezign\yii2\audit\components\Helper;
 use Yii;
@@ -154,8 +155,7 @@ class AuditEntry extends ActiveRecord
 
         $this->route = $app->requestedAction ? $app->requestedAction->uniqueId : null;
         if ($request instanceof \yii\web\Request) {
-            $user = $app->user;
-            $this->user_id        = $user->isGuest ? 0 : $user->id;
+            $this->user_id        = Audit::getInstance()->getUserId();
             $this->ip             = $request->userIP;
             $this->ajax           = $request->isAjax;
             $this->request_method = $request->method;
@@ -175,8 +175,7 @@ class AuditEntry extends ActiveRecord
         $request = $app->request;
 
         if (!$this->user_id && $request instanceof \yii\web\Request) {
-            $user = $app->user;
-            $this->user_id = $user->isGuest ? 0 : $user->id;
+            $this->user_id = Audit::getInstance()->getUserId();
         }
 	
         $this->duration = microtime(true) - YII_BEGIN_TIME;

--- a/tests/codeception/_app/models/User.php
+++ b/tests/codeception/_app/models/User.php
@@ -63,4 +63,12 @@ class User extends ActiveRecord implements IdentityInterface
         $user = self::findOne($id);
         return $user ? $user->username : $id;
     }
+
+    /**
+     * @return int|string
+     */
+    public static function userIdCallback()
+    {
+        return 1;
+    }
 }

--- a/tests/codeception/unit/AuditUserIdCallbackTest.php
+++ b/tests/codeception/unit/AuditUserIdCallbackTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace tests\codeception\unit;
+
+use bedezign\yii2\audit\Audit;
+use bedezign\yii2\audit\tests\UnitTester;
+use Codeception\Specify;
+use Yii;
+
+/**
+ * AuditUserIdCallbackTest
+ */
+class AuditUserIdCallbackTest extends AuditTestCase
+{
+    use Specify;
+
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
+
+    public function testUserIdCallbackTest()
+    {
+        Audit::getInstance()->userIdCallback = ['tests\app\models\User', 'userIdCallback'];
+        $this->assertEquals(Audit::getInstance()->getUserId(), '1');
+    }
+
+}


### PR DESCRIPTION
I created "getUserId" method, but it can be confused with "getUserIdentifier".
May be rename one of them?

Extract PR from #176  to new branch. 