### PR TITLE
Fix dbPanel errors

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -12,7 +12,6 @@ namespace bedezign\yii2\audit;
 
 use bedezign\yii2\audit\components\panels\Panel;
 use bedezign\yii2\audit\models\AuditEntry;
-use bedezign\yii2\audit\models\AuditError;
 use Yii;
 use yii\base\ActionEvent;
 use yii\base\Application;
@@ -152,6 +151,11 @@ class Audit extends Module
      * @var LogTarget
      */
     public $logTarget;
+
+    /**
+     * @see \yii\debug\Module::$traceLine
+     */
+    public $traceLine = \yii\debug\Module::DEFAULT_IDE_TRACELINE;
 
     /**
      * @var array

--- a/src/panels/DbPanel.php
+++ b/src/panels/DbPanel.php
@@ -39,7 +39,13 @@ class DbPanel extends \yii\debug\panels\DbPanel
     public function getDetail()
     {
         $searchModel = new Db();
-        $dataProvider = $searchModel->search(Yii::$app->request->getQueryParams(), $this->getModels());
+
+        if (!$searchModel->load(Yii::$app->request->getQueryParams())) {
+            $searchModel->load($this->defaultFilter, '');
+        }
+
+        $dataProvider = $searchModel->search($this->getModels());
+        $dataProvider->getSort()->defaultOrder = $this->defaultOrder;
 
         return Yii::$app->view->render('@yii/debug/views/default/panels/db/detail', [
             'panel' => $this,


### PR DESCRIPTION
Some fixes related to yi2-debug v2.0.7
1. yii\debug\models\search\DB::search signature changed:  yiisoft/yii2-debug#8
2. Implement yii\debug\Module::$traceLine property in Audit.  yiisoft/yii2-debug#162