### PR TITLE
reduced number of default panels

### DIFF
--- a/src/Audit.php
+++ b/src/Audit.php
@@ -129,12 +129,12 @@ class Audit extends Module
      */
     public $panels = [
         'audit/request',
-        'audit/db',
-        'audit/log',
+        //'audit/db',
+        //'audit/log',
         'audit/mail',
-        'audit/profiling',
+        //'audit/profiling',
         'audit/trail',
-        'audit/javascript',
+        //'audit/javascript', # also enable JSLoggingAsset
         // 'audit/asset',
         // 'audit/config',
 


### PR DESCRIPTION
Significantly reduces the amount of data being logged, a bit more defensive default setting for i.e. also running the module in staging or production

I would also update the docs, if this would be OK.