### PR TITLE
Ignore attributes when they contain arrays

### DIFF
--- a/src/AuditTrailBehavior.php
+++ b/src/AuditTrailBehavior.php
@@ -235,7 +235,7 @@ class AuditTrailBehavior extends Behavior
         $newAttributes = $this->cleanAttributes($this->owner->getAttributes());
         $oldAttributes = $this->cleanAttributes($this->getOldAttributes());
         // If no difference then get out of here
-        if (count(array_diff_assoc($newAttributes, $oldAttributes)) <= 0) {
+        if (is_array($newAttributes) || is_array($oldAttributes) || count(array_diff_assoc($newAttributes, $oldAttributes)) <= 0) {
             return;
         }
         // Get the trail data

--- a/src/AuditTrailBehavior.php
+++ b/src/AuditTrailBehavior.php
@@ -234,8 +234,18 @@ class AuditTrailBehavior extends Behavior
         // Get the new and old attributes
         $newAttributes = $this->cleanAttributes($this->owner->getAttributes());
         $oldAttributes = $this->cleanAttributes($this->getOldAttributes());
+
+        // ensure to handle serialized attributes properly
+        foreach($newAttributes as $key => $value)
+            if(is_array($newAttributes[$key]))
+                $newAttributes[$key] = implode(',', $newAttributes[$key]);
+
+        foreach($oldAttributes as $key => $value)
+            if(is_array($oldAttributes[$key]))
+                $oldAttributes[$key] = implode(',', $oldAttributes[$key]);
+
         // If no difference then get out of here
-        if (is_array($newAttributes) || is_array($oldAttributes) || count(array_diff_assoc($newAttributes, $oldAttributes)) <= 0) {
+        if (count(array_diff_assoc($newAttributes, $oldAttributes)) <= 0) {
             return;
         }
         // Get the trail data

--- a/src/AuditTrailBehavior.php
+++ b/src/AuditTrailBehavior.php
@@ -4,6 +4,7 @@ namespace bedezign\yii2\audit;
 use Yii;
 use yii\base\Behavior;
 use yii\db\ActiveRecord;
+use yii\helpers\Json;
 use bedezign\yii2\audit\models\AuditTrail;
 use yii\db\Query;
 
@@ -238,11 +239,11 @@ class AuditTrailBehavior extends Behavior
         // ensure to handle serialized attributes properly
         foreach($newAttributes as $key => $value)
             if(is_array($newAttributes[$key]))
-                $newAttributes[$key] = implode(',', $newAttributes[$key]);
+                $newAttributes[$key] = Json::encode($newAttributes[$key]);
 
         foreach($oldAttributes as $key => $value)
             if(is_array($oldAttributes[$key]))
-                $oldAttributes[$key] = implode(',', $oldAttributes[$key]);
+                $oldAttributes[$key] = Json::encode($oldAttributes[$key]);
 
         // If no difference then get out of here
         if (count(array_diff_assoc($newAttributes, $oldAttributes)) <= 0) {


### PR DESCRIPTION
This is an small workaround to avoid this error when using arrays as attribute values (which should be serialized somehow before saving and unserialized in afterFind()):

![image](https://cloud.githubusercontent.com/assets/654271/22242624/4eb41184-e224-11e6-9cf7-51f8bcd153e9.png)

We should consider supporting this case properly in an future yii2-audit version.

