### PR TITLE
fixed yii2-debug constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=5.4.0",
         "ext-bcmath": "*",
         "yiisoft/yii2": "2.*",
-        "yiisoft/yii2-debug": "2.*",
+        "yiisoft/yii2-debug": "^2.0.7",
         "2amigos/yii2-chartjs-widget": "2.0.1 || 3.*",
         "phpspec/php-diff": "1.*"
     },


### PR DESCRIPTION
The commit https://github.com/bedezign/yii2-audit/commit/18ae5035d443ffd7a56774cd8e1ad5feebb7a5eb introduced a dependency on a constant, add in `2.0.7` of yii2-debug, see https://github.com/yiisoft/yii2-debug/commit/ed07955e80185874d4d244e8e5c25cd8a890e82e