### PR TITLE
Improve performance on home views by optimising database queries

### DIFF
--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -30,11 +30,14 @@ $this->registerCss('canvas {width: 100% !important;height: 400px;}');
                     $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
                 }
                 $results = AuditEntry::find()
-                    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+                    ->select(["COUNT(DISTINCT id) as count", "created AS day"])
                     ->where(['between', 'created',
                         date('Y-m-d 00:00:00', $startDate),
                         date('Y-m-d 23:59:59')])
                     ->groupBy("day")->indexBy('day')->column();
+                array_walk($results, function ($count, &$key) {
+                    $key = date('D: Y-m-d', date_create($key));
+                });
                 $results = array_merge($defaults, $results);
 
                 echo ChartJs::widget([

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -24,13 +24,19 @@ $this->registerCss('canvas {width: 100% !important;height: 400px;}');
 
             <div class="well">
                 <?php
-                $days = [];
-                $count = [];
+                $defaults = [];
+                $startDate = strtotime('-6 days');
                 foreach (range(-6, 0) as $day) {
-                    $date = strtotime($day . 'days');
-                    $days[] = date('D: Y-m-d', $date);
-                    $count[] = AuditEntry::find()->where(['between', 'created', date('Y-m-d 00:00:00', $date), date('Y-m-d 23:59:59', $date)])->count();
+                    $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
                 }
+                $results = AuditEntry::find()
+                    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+                    ->where(['between', 'created',
+                        date('Y-m-d 00:00:00', $startDate),
+                        date('Y-m-d 23:59:59')])
+                    ->groupBy("day")->indexBy('day')->column();
+                $results = array_merge($defaults, $results);
+
                 echo ChartJs::widget([
                     'type' => 'bar',
                     'options' => [
@@ -41,14 +47,14 @@ $this->registerCss('canvas {width: 100% !important;height: 400px;}');
                         'tooltips' => ['enabled' => false],
                     ],
                     'data' => [
-                        'labels' => $days,
+                        'labels' => array_keys($results),
                         'datasets' => [
                             [
                                 'fillColor' => 'rgba(151,187,205,0.5)',
                                 'strokeColor' => 'rgba(151,187,205,1)',
                                 'pointColor' => 'rgba(151,187,205,1)',
                                 'pointStrokeColor' => '#fff',
-                                'data' => $count,
+                                'data' => array_values($results),
                             ],
                         ],
                     ]

--- a/src/views/default/panels/error/chart.php
+++ b/src/views/default/panels/error/chart.php
@@ -11,11 +11,14 @@ foreach (range(-6, 0) as $day) {
     $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
 }
 $results = AuditError::find()
-    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+    ->select(["COUNT(DISTINCT id) as count", "created AS day"])
     ->where(['between', 'created',
         date('Y-m-d 00:00:00', $startDate),
         date('Y-m-d 23:59:59')])
     ->groupBy("day")->indexBy('day')->column();
+array_walk($results, function ($count, &$key) {
+    $key = date('D: Y-m-d', date_create($key));
+});
 $results = array_merge($defaults, $results);
 
 echo ChartJs::widget([

--- a/src/views/default/panels/error/chart.php
+++ b/src/views/default/panels/error/chart.php
@@ -5,13 +5,18 @@ use bedezign\yii2\audit\models\AuditError;
 use bedezign\yii2\audit\panels\ErrorPanel;
 use dosamigos\chartjs\ChartJs;
 
-$days = [];
-$count = [];
+$defaults = [];
+$startDate = strtotime('-6 days');
 foreach (range(-6, 0) as $day) {
-    $date = strtotime($day . 'days');
-    $days[] = date('D: Y-m-d', $date);
-    $count[] = AuditError::find()->where(['between', 'created', date('Y-m-d 00:00:00', $date), date('Y-m-d 23:59:59', $date)])->count();
+    $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
 }
+$results = AuditError::find()
+    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+    ->where(['between', 'created',
+        date('Y-m-d 00:00:00', $startDate),
+        date('Y-m-d 23:59:59')])
+    ->groupBy("day")->indexBy('day')->column();
+$results = array_merge($defaults, $results);
 
 echo ChartJs::widget([
     'type' => 'bar',
@@ -20,14 +25,14 @@ echo ChartJs::widget([
         'tooltips' => ['enabled' => false],
     ],
     'data' => [
-        'labels' => $days,
+        'labels' => array_keys($results),
         'datasets' => [
             [
                 'fillColor' => 'rgba(151,187,205,0.5)',
                 'strokeColor' => 'rgba(151,187,205,1)',
                 'pointColor' => 'rgba(151,187,205,1)',
                 'pointStrokeColor' => '#fff',
-                'data' => $count,
+                'data' => array_values($results),
             ],
         ],
     ]

--- a/src/views/default/panels/javascript/chart.php
+++ b/src/views/default/panels/javascript/chart.php
@@ -5,13 +5,18 @@ use bedezign\yii2\audit\models\AuditJavascript;
 use bedezign\yii2\audit\panels\JavascriptPanel;
 use dosamigos\chartjs\ChartJs;
 
-$days = [];
-$count = [];
+$defaults = [];
+$startDate = strtotime('-6 days');
 foreach (range(-6, 0) as $day) {
-    $date = strtotime($day . 'days');
-    $days[] = date('D: Y-m-d', $date);
-    $count[] = AuditJavascript::find()->where(['between', 'created', date('Y-m-d 00:00:00', $date), date('Y-m-d 23:59:59', $date)])->count();
+    $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
 }
+$results = AuditJavascript::find()
+    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+    ->where(['between', 'created',
+        date('Y-m-d 00:00:00', $startDate),
+        date('Y-m-d 23:59:59')])
+    ->groupBy("day")->indexBy('day')->column();
+$results = array_merge($defaults, $results);
 
 echo ChartJs::widget([
     'type' => 'bar',
@@ -20,14 +25,14 @@ echo ChartJs::widget([
         'tooltips' => ['enabled' => false],
     ],
     'data' => [
-        'labels' => $days,
+        'labels' => array_keys($results),
         'datasets' => [
             [
                 'fillColor' => 'rgba(151,187,205,0.5)',
                 'strokeColor' => 'rgba(151,187,205,1)',
                 'pointColor' => 'rgba(151,187,205,1)',
                 'pointStrokeColor' => '#fff',
-                'data' => $count,
+                'data' => array_keys($results),
             ],
         ],
     ]

--- a/src/views/default/panels/javascript/chart.php
+++ b/src/views/default/panels/javascript/chart.php
@@ -11,11 +11,14 @@ foreach (range(-6, 0) as $day) {
     $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
 }
 $results = AuditJavascript::find()
-    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+    ->select(["COUNT(DISTINCT id) as count", "created AS day"])
     ->where(['between', 'created',
         date('Y-m-d 00:00:00', $startDate),
         date('Y-m-d 23:59:59')])
     ->groupBy("day")->indexBy('day')->column();
+array_walk($results, function ($count, &$key) {
+    $key = date('D: Y-m-d', date_create($key));
+});
 $results = array_merge($defaults, $results);
 
 echo ChartJs::widget([

--- a/src/views/default/panels/mail/chart.php
+++ b/src/views/default/panels/mail/chart.php
@@ -11,11 +11,14 @@ foreach (range(-6, 0) as $day) {
     $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
 }
 $results = AuditMail::find()
-    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+    ->select(["COUNT(DISTINCT id) as count", "created AS day"])
     ->where(['between', 'created',
         date('Y-m-d 00:00:00', $startDate),
         date('Y-m-d 23:59:59')])
     ->groupBy("day")->indexBy('day')->column();
+array_walk($results, function ($count, &$key) {
+    $key = date('D: Y-m-d', date_create($key));
+});
 $results = array_merge($defaults, $results);
 
 echo ChartJs::widget([

--- a/src/views/default/panels/trail/chart.php
+++ b/src/views/default/panels/trail/chart.php
@@ -11,11 +11,14 @@ foreach (range(-6, 0) as $day) {
     $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
 }
 $results = AuditTrail::find()
-    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+    ->select(["COUNT(DISTINCT id) as count", "created AS day"])
     ->where(['between', 'created',
         date('Y-m-d 00:00:00', $startDate),
         date('Y-m-d 23:59:59')])
     ->groupBy("day")->indexBy('day')->column();
+array_walk($results, function ($count, &$key) {
+    $key = date('D: Y-m-d', date_create($key));
+});
 $results = array_merge($defaults, $results);
 
 echo ChartJs::widget([

--- a/src/views/default/panels/trail/chart.php
+++ b/src/views/default/panels/trail/chart.php
@@ -5,13 +5,18 @@ use bedezign\yii2\audit\models\AuditTrail;
 use bedezign\yii2\audit\panels\TrailPanel;
 use dosamigos\chartjs\ChartJs;
 
-$days = [];
-$count = [];
+$defaults = [];
+$startDate = strtotime('-6 days');
 foreach (range(-6, 0) as $day) {
-    $date = strtotime($day . 'days');
-    $days[] = date('D: Y-m-d', $date);
-    $count[] = AuditTrail::find()->where(['between', 'created', date('Y-m-d 00:00:00', $date), date('Y-m-d 23:59:59', $date)])->count();
+    $defaults[date('D: Y-m-d', strtotime($day . 'days'))] = 0;
 }
+$results = AuditTrail::find()
+    ->select(["COUNT(DISTINCT id) as count", "DATE_FORMAT(created, '%a: %Y-%m-%d') AS day"])
+    ->where(['between', 'created',
+        date('Y-m-d 00:00:00', $startDate),
+        date('Y-m-d 23:59:59')])
+    ->groupBy("day")->indexBy('day')->column();
+$results = array_merge($defaults, $results);
 
 echo ChartJs::widget([
     'type' => 'bar',
@@ -20,14 +25,14 @@ echo ChartJs::widget([
         'tooltips' => ['enabled' => false],
     ],
     'data' => [
-        'labels' => $days,
+        'labels' => array_keys($results),
         'datasets' => [
             [
                 'fillColor' => 'rgba(151,187,205,0.5)',
                 'strokeColor' => 'rgba(151,187,205,1)',
                 'pointColor' => 'rgba(151,187,205,1)',
                 'pointStrokeColor' => '#fff',
-                'data' => $count,
+                'data' => array_values($results),
             ],
         ],
     ]


### PR DESCRIPTION
We use yii2-audit for some projects at my workplace (:+1:), and for a while now, we've been unable to access the home page of the audit module. I discovered this was due to the number of database queries being made to render that page (35 queries) combined with the size of our audit records (at least hundreds of thousands). 

This PR removes the multiple database queries and replaces them with one for each resource (`Trail`, `Error`, `Entry`, `Mail`, `Javascript`), bringing the number of queries to render the homepage down to 5.

All tests passing, PSR-2 passing