### PR TITLE
Added namespaces in the migration files.

### DIFF
--- a/src/migrations/m150626_000001_create_audit_entry.php
+++ b/src/migrations/m150626_000001_create_audit_entry.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000002_create_audit_data.php
+++ b/src/migrations/m150626_000002_create_audit_data.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000003_create_audit_error.php
+++ b/src/migrations/m150626_000003_create_audit_error.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000004_create_audit_trail.php
+++ b/src/migrations/m150626_000004_create_audit_trail.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000005_create_audit_javascript.php
+++ b/src/migrations/m150626_000005_create_audit_javascript.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000006_create_audit_mail.php
+++ b/src/migrations/m150626_000006_create_audit_mail.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150714_000001_alter_audit_data.php
+++ b/src/migrations/m150714_000001_alter_audit_data.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m170126_000001_alter_audit_mail.php
+++ b/src/migrations/m170126_000001_alter_audit_mail.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace bedezign\yii2\audit\migrations;
+
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 


### PR DESCRIPTION
As per release of Yii 2.0.10, namespaced migrations can be used. Developers who are using this feature will appreciate it  if you can update your migration files to use namespaces.

<img width="469" alt="Screen Shot 2019-07-25 at 3 25 33 PM" src="https://user-images.githubusercontent.com/60449/61856114-0fb0a980-aef4-11e9-813b-5eac987d9907.png">
<img width="1029" alt="Screen Shot 2019-07-25 at 3 12 30 PM" src="https://user-images.githubusercontent.com/60449/61856116-10494000-aef4-11e9-87f4-7e178c654cb3.png">