### PR TITLE
Remove namespaces from migrations to support path migrations again

### DIFF
--- a/src/migrations/m150626_000001_create_audit_entry.php
+++ b/src/migrations/m150626_000001_create_audit_entry.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000002_create_audit_data.php
+++ b/src/migrations/m150626_000002_create_audit_data.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000003_create_audit_error.php
+++ b/src/migrations/m150626_000003_create_audit_error.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000004_create_audit_trail.php
+++ b/src/migrations/m150626_000004_create_audit_trail.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000005_create_audit_javascript.php
+++ b/src/migrations/m150626_000005_create_audit_javascript.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150626_000006_create_audit_mail.php
+++ b/src/migrations/m150626_000006_create_audit_mail.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m150714_000001_alter_audit_data.php
+++ b/src/migrations/m150714_000001_alter_audit_data.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 

--- a/src/migrations/m170126_000001_alter_audit_mail.php
+++ b/src/migrations/m170126_000001_alter_audit_mail.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace bedezign\yii2\audit\migrations;
-
 use bedezign\yii2\audit\components\Migration;
 use yii\db\Schema;
 


### PR DESCRIPTION
That was the main problem why we did not upgrade to <1.1.2